### PR TITLE
Added mta to the "not to uninstall" list

### DIFF
--- a/debian/prerm
+++ b/debian/prerm
@@ -20,7 +20,7 @@ case "$1" in
 	    which cozy-monitor >/dev/null 2>&1
 	    RESULT=$?
 	    if [ "$RESULT" = "0" ]; then
-		    APPS="$(cozy-monitor status | grep -vE '(postfix|couch|controller|data-system|ds|home|proxy)' | sed 's/:.*//;s/\[Error//' | xargs echo)"
+		    APPS="$(cozy-monitor status | grep -vE '(mta|postfix|couch|controller|data-system|ds|home|proxy)' | sed 's/:.*//;s/\[Error//' | xargs echo)"
 		    APPS="$APPS proxy home data-system"
 		    for app in $APPS ; do cozy-monitor uninstall $app ; done
 	    fi


### PR DESCRIPTION
Without this, the prerm is going to fail on most systems because `cozy-monitor status` can list the MTA as `mta`, and trying to uninstall it will cause `cozy-monitor uninstall` to fail.
