### PR TITLE
Fixed uninstall in case of errors

### DIFF
--- a/debian/cozy-standalone.prerm
+++ b/debian/cozy-standalone.prerm
@@ -20,7 +20,7 @@ case "$1" in
 	    which cozy-monitor >/dev/null 2>&1
 	    RESULT=$?
 	    if [ "$RESULT" = "0" ]; then
-		    APPS="$(cozy-monitor status | grep -vE '(postfix|mta|couch|controller|data-system|ds|home|proxy)' | sed 's/:.*//;s/\[Error//' | xargs echo)"
+		    APPS="$(cozy-monitor status | grep -vE '(postfix|mta|couch|controller|data-system|ds|home|proxy|error)' | sed 's/:.*//;s/\[Error//' | xargs echo)"
 		    APPS="$APPS proxy home data-system"
 		    for app in $APPS ; do cozy-monitor uninstall $app ; done
 	    fi


### PR DESCRIPTION
If an error is displayed by the `cozy-monitor status` command, the line containing it isn't excluded from the apps list. As a result, if I get the error "error - The Cozy Data System looks not started", the script as it is now will try to uninstall the apps "error", "The", "Cozy", and so on. Adding "error" to the exclusions list will prevent this from happening as it will exclude all lines beginning with the word "error".
